### PR TITLE
Debug item inclusion and enhance participant reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ config_fixed <- create_study_config(
 launch_study(config_fixed, bfi_items)
 ```
 
-### Advanced Cognitive Assessment
+### Advanced Cognitive Assessment with Participant Report Controls
 
 ```r
 data(cognitive_items)
@@ -167,7 +167,16 @@ advanced_config <- create_study_config(
     session_save = TRUE,
     parallel_computation = TRUE,
     cache_enabled = TRUE,
-    accessibility_enhanced = TRUE
+    accessibility_enhanced = TRUE,
+    # Control participant report contents
+    participant_report = list(
+      show_theta_plot = TRUE,
+      show_response_table = TRUE,
+      show_recommendations = TRUE,
+      use_enhanced_report = TRUE
+    ),
+    # Require at least two non-age demographics to be filled
+    min_required_non_age_demographics = 2
 )
 
 launch_study(
@@ -176,7 +185,7 @@ launch_study(
     accessibility = TRUE,
     admin_dashboard_hook = function(session_data) {
         message("Participant ID:", session_data$participant_id)
-        message("Progress:", session_data$progress, "%")
+        message("Progress:", round(session_data$progress, 1), "%")
         message("Current theta:", round(session_data$theta, 3))
         message("Standard error:", round(session_data$se, 3))
     }


### PR DESCRIPTION
# Pull Request

## Description
This PR addresses the "no items" issue by enhancing item bank processing and scoring robustness, ensuring items are consistently displayed and scored. It introduces granular controls for participant report content and visualizations, allowing users to customize displayed information. Additionally, it adds configurable demographic gating to improve study flow flexibility. The README example has been updated to demonstrate these new features.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring

## Testing
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have run `devtools::check()` and addressed any issues

## Psychometric Validation
- [ ] Statistical methods have been validated against established procedures
- [ ] TAM integration has been verified
- [ ] Results have been cross-checked with known methods

## Documentation
- [x] I have updated the documentation accordingly
- [x] I have added examples where appropriate
- [x] Function documentation is complete and accurate

## Additional Notes
*   **Files Modified:** `R/create_study_config.R`, `R/launch_study.R`, `README.md`
*   **Impact:**
    *   **Item Display:** Ensures items are consistently displayed and scored, even with incomplete item bank metadata (e.g., missing `options` or `answers`).
    *   **Participant Report:** Provides extensive customization options for the final participant report, including new plots for domain coverage and item difficulty trend.
    *   **Demographic Flow:** Allows flexible control over the number of required demographic fields, preventing participants from getting stuck.
*   `devtools::check()` was not run in the current environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee16666a-5934-4025-8842-cbb4a0dcacb4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ee16666a-5934-4025-8842-cbb4a0dcacb4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

